### PR TITLE
#4500 Modifying application.yaml as required by openshift.io osio pipeline library

### DIFF
--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -3,6 +3,14 @@ kind: Template
 metadata:
   name: thorntail-health-check
 parameters:
+- name: SUFFIX_NAME
+  description: The suffix name for the template objects
+  displayName: Suffix name
+  value: ''
+- name: RELEASE_VERSION
+  description: The release version number of application
+  displayName: Release version
+  value: 1.0.0
 - name: SOURCE_REPOSITORY_URL
   description: The source URL for the application
   displayName: Source URL
@@ -28,7 +36,9 @@ objects:
 - apiVersion: v1
   kind: ImageStream
   metadata:
-    name: thorntail-health-check
+    name: thorntail-health-check${SUFFIX_NAME}
+    labels:
+      version: ${RELEASE_VERSION}
   spec: {}
 - apiVersion: v1
   kind: ImageStream
@@ -43,12 +53,14 @@ objects:
 - apiVersion: v1
   kind: BuildConfig
   metadata:
-    name: thorntail-health-check
+    name: thorntail-health-check-s2i${SUFFIX_NAME}
+    labels:
+      version: ${RELEASE_VERSION}
   spec:
     output:
       to:
         kind: ImageStreamTag
-        name: thorntail-health-check:latest
+        name: 'thorntail-health-check${SUFFIX_NAME}:${RELEASE_VERSION}'
     postCommit: {}
     resources: {}
     source:
@@ -61,7 +73,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: runtime-thorntail-health-check:latest
+          name: 'runtime-thorntail-health-check:latest'
         incremental: true
         env:
         - name: MAVEN_ARGS_APPEND
@@ -85,7 +97,8 @@ objects:
       expose: "true"
       app: thorntail-health-check
       group: io.openshift.boosters
-    name: thorntail-health-check
+      version: ${RELEASE_VERSION}
+    name: thorntail-health-check${SUFFIX_NAME}
   spec:
     ports:
     - name: http
@@ -101,7 +114,8 @@ objects:
     labels:
       app: thorntail-health-check
       group: io.openshift.boosters
-    name: thorntail-health-check
+      version: ${RELEASE_VERSION}
+    name: thorntail-health-check${SUFFIX_NAME}
   spec:
     replicas: 1
     revisionHistoryLimit: 2
@@ -117,6 +131,7 @@ objects:
         labels:
           app: thorntail-health-check
           group: io.openshift.boosters
+          version: ${RELEASE_VERSION}
       spec:
         containers:
         - env:
@@ -124,7 +139,7 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: thorntail-health-check:latest
+          image: ""
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 2
@@ -167,7 +182,7 @@ objects:
         - thorntail
         from:
           kind: ImageStreamTag
-          name: thorntail-health-check:latest
+          name: 'thorntail-health-check${SUFFIX_NAME}:${RELEASE_VERSION}'
       type: ImageChange
 - apiVersion: v1
   kind: Route
@@ -175,10 +190,11 @@ objects:
     labels:
       app: thorntail-health-check
       group: io.openshift.boosters
-    name: thorntail-health-check
+      version: ${RELEASE_VERSION}
+    name: thorntail-health-check${SUFFIX_NAME}
   spec:
     port:
       targetPort: 8080
     to:
       kind: Service
-      name: thorntail-health-check
+      name: thorntail-health-check${SUFFIX_NAME}


### PR DESCRIPTION
openshiftio/openshift.io#4500
This changed include the below which is required by osio pipeline library (https://github.com/fabric8io/osio-pipeline) :

1. Adds parameter - RELEASE_VERSION which is basically the
build number and will be used to differentiate between
the resources of the particular build.
2. Adds parameter - SUFFIX_NAME which is an identifier to
differentiate between the master build or other branches.
More like a master build or PR build. So whenever there is
a change in the resources of a particular branch, it applies
to the resource of that branch only. The SUFFIX_NAME variable
is used in the name of all resources.
